### PR TITLE
18 add get login info

### DIFF
--- a/logic/db_access.php
+++ b/logic/db_access.php
@@ -30,7 +30,7 @@ function openDb() :PDO {
  * @retval [array] 選択したテーブルのカラムとレコード全件を格納した配列。
  */
 function getDbAll(PDO $dbh, string $tableName): array {
-    $sql = 'SELECT * FROM `$tableName`';
+    $sql = "SELECT * FROM `$tableName`";
     $stmt = $dbh->prepare($sql);
     $stmt->execute();
     $result = $stmt->fetchAll();
@@ -41,12 +41,12 @@ function getDbAll(PDO $dbh, string $tableName): array {
  * @brief DBからログイン情報を配列で取得する。
  * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
  * @param $email [string] ログインするメールアドレスを指定。
- * @retval [array] DBから取得したメールアドレスとパスワード、氏名を格納した配列.
+ * @retval [array] DBから取得したメールアドレスとパスワード、氏名を格納した配列。
  */
 function getLoginInfo(PDO $dbh, string $email): array {
-    $sql = 'SELECT `member_email`, `member_password`, `member_name`
+    $sql = "SELECT `member_email`, `member_password`, `member_name`
             FROM `m_member`
-            WHERE `member_email` = :member_email';
+            WHERE `member_email` = :member_email";
     $stmt = $dbh->prepare($sql);
     $stmt->bindParam(":member_email", $email, PDO::PARAM_STR);
     $stmt->execute();

--- a/logic/db_access.php
+++ b/logic/db_access.php
@@ -30,8 +30,25 @@ function openDb() :PDO {
  * @retval [array] 選択したテーブルのカラムとレコード全件を格納した配列。
  */
 function getDbAll(PDO $dbh, string $tableName): array {
-    $sql = "SELECT * FROM `$tableName`";
+    $sql = 'SELECT * FROM `$tableName`';
     $stmt = $dbh->prepare($sql);
+    $stmt->execute();
+    $result = $stmt->fetchAll();
+    return $result;
+}
+
+/**
+ * @brief DBからログイン情報を配列で取得する。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $email [string] ログインするメールアドレスを指定。
+ * @retval [array] DBから取得したメールアドレスとパスワード、氏名を格納した配列.
+ */
+function getLoginInfo(PDO $dbh, string $email): array {
+    $sql = 'SELECT `member_email`, `member_password`, `member_name`
+            FROM `m_member`
+            WHERE `member_email` = :member_email';
+    $stmt = $dbh->prepare($sql);
+    $stmt->bindParam(":member_email", $email, PDO::PARAM_STR);
     $stmt->execute();
     $result = $stmt->fetchAll();
     return $result;

--- a/test/test_db_access.php
+++ b/test/test_db_access.php
@@ -29,6 +29,21 @@ function testGetDbAll(PDO $dbh, string $tableName): void {
     echo ' カラム数:' . count($allTable[0]) / count($allTable) . '<br>' . PHP_EOL;
 }
 
+/**
+ * @brief getLoginInfo()でログイン情報を配列で取得できているかテスト。
+ * @param $dbh [PDO] dbOpen()で取得したデータベースオブジェクトを指定。
+ * @param $email [string] 取得する会員のメールアドレスを指定。
+ */
+function testGetLoginInfo(PDO $dbh, string $email): void {
+    $loginInfo = getLoginInfo($dbh, $email);
+    echo 'testGetLoginInfo : ' . '<br>' . PHP_EOL;
+    echo ' メール:' . $loginInfo[0]['member_email'] . '<br>' . PHP_EOL;
+    echo ' パスワード:' . $loginInfo[0]['member_password'] . '<br>' . PHP_EOL;
+    echo ' ユーザ名:' . $loginInfo[0]['member_name'] . '<br>' . PHP_EOL;
+}
+
 testOpenDb();
 testGetDbAll(openDb(), 'm_product');
 testGetDbAll(openDb(), 'm_member');
+testGetLoginInfo(openDb(), 'user1@example.com');
+testGetLoginInfo(openDb(), 'user2@example.com');


### PR DESCRIPTION
# 概要
#18 の通り、ログイン情報を配列で取得する関数を実装。  

# 単体テスト
$ php .\test\test_db_access.php
testGetSaltTrue : passed\<br>
testGetDbAll : \<br>
 テーブル名:m_product\<br>
 レコード数:2\<br>
 カラム数:6\<br>
testGetDbAll : \<br>
 テーブル名:m_member\<br>
 レコード数:2\<br>
 カラム数:12\<br>
testGetLoginInfo : \<br>
 メール:user1@example.com\<br>
 パスワード:$2y$10$MH15ZWrCfldgtDwa2MkPN..PqFCfeaj1QbZChQAQg0rncNAaRRq0a\<br>
 ユーザ名:ユーザ太郎\<br>
testGetLoginInfo : \<br>
 メール:user2@example.com\<br>
 パスワード:password2\<br>
 ユーザ名:ユーザ花子\<br>