### PR TITLE
30 add creditcard

### DIFF
--- a/logic/db_mod.php
+++ b/logic/db_mod.php
@@ -68,3 +68,26 @@ function insertDbMember(PDO $dbh, string $password, string $name, string $ruby,
     $stmt->bindParam(':gender_id', $gender_id);
     $stmt->execute();
 }
+
+/**
+ * @brief クレジットカードの決済情報をDBに保存(通常は同じDBに保存しないが今回は練習用)。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $member_cd [string] 会員コード。
+ * @param $number [string] カード番号。
+ * @param $expiration [string] 有効期限。
+ * @param $name [string] 名義人氏名。
+ * @param $cvc [string] セキュリティコード。
+ */
+function insertDbCreditCard(PDO $dbh, string $member_cd, string $number, string $expiration,
+                            string $name, string $cvc): void {
+    $sql = "INSERT INTO `t_credit_card` (`member_cd`, `credit_card_number`,
+                        `credit_card_expiration`, `credit_card_name`, `credit_card_cvc`) 
+            VALUES (:member_cd, :number, :expiration, :name, :cvc)";
+    $stmt = $dbh->prepare($sql);
+    $stmt->bindParam(':member_cd', $member_cd);
+    $stmt->bindParam(':number', $number);
+    $stmt->bindParam(':expiration', $expiration);
+    $stmt->bindParam(':name', $name);
+    $stmt->bindParam(':cvc', $cvc);
+    $stmt->execute();
+}

--- a/test/test_insert_db_credit_card.php
+++ b/test/test_insert_db_credit_card.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * @file test_insert_db_credit_card.php
+ * @brief insertDbCreditCard() の単体テスト。
+ * @author nagata
+ */
+
+require_once __DIR__ . '/../logic/db_access.php';
+require_once __DIR__ . '/../logic/db_mod.php';
+
+/**
+ * @brief クレジットカードの決済情報をDBに保存できるかの単体テスト(通常は保存しないが今回は練習用)。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $member_cd [string] 会員コード。
+ * @param $number [string] カード番号。
+ * @param $expiration [string] 有効期限。
+ * @param $name [string] 名義人氏名。
+ * @param $cvc [string] セキュリティコード。
+ */
+function testInsertDbCreditCard(PDO $dbh, string $member_cd, string $number, string $expiration,
+                            string $name, string $cvc): void {
+    insertDbCreditCard($dbh, $member_cd, $number, $expiration, $name, $cvc);
+    var_dump(getDbAll($dbh, 't_credit_card'));
+}
+
+$dbh = openDb();
+testInsertDbCreditCard($dbh, '3', '123', '2024-01-31', 'USER3', '333');


### PR DESCRIPTION
# 概要
#30 の通り、クレジットカード情報をDBに保存する関数を実装。  

# 単体テストの結果
php .\test\test_insert_db_credit_card.php
array(3) {
  [0]=>
  array(10) {
    ["member_cd"]=>
    int(1)
    [0]=>
    int(1)
    ["credit_card_number"]=>
    string(16) "1234567890123456"
    [1]=>
    string(16) "1234567890123456"
    ["credit_card_expiration"]=>
    string(10) "2028-01-31"
    [2]=>
    string(10) "2028-01-31"
    ["credit_card_name"]=>
    string(9) "USER TARO"
    [3]=>
    string(9) "USER TARO"
    ["credit_card_cvc"]=>
    string(3) "111"
    [4]=>
    string(3) "111"
  }
  [1]=>
  array(10) {
    ["member_cd"]=>
    int(2)
    [0]=>
    int(2)
    ["credit_card_number"]=>
    string(16) "1234567891123456"
    [1]=>
    string(16) "1234567891123456"
    ["credit_card_expiration"]=>
    string(10) "2029-01-31"
    [2]=>
    string(10) "2029-01-31"
    ["credit_card_name"]=>
    string(11) "USER HANAKO"
    [3]=>
    string(11) "USER HANAKO"
    ["credit_card_cvc"]=>
    string(3) "222"
    [4]=>
    string(3) "222"
  }
  [2]=>
  array(10) {
    ["member_cd"]=>
    int(3)
    [0]=>
    int(3)
    ["credit_card_number"]=>
    string(3) "123"
    [1]=>
    string(3) "123"
    ["credit_card_expiration"]=>
    string(10) "2024-01-31"
    [2]=>
    string(10) "2024-01-31"
    ["credit_card_name"]=>
    string(5) "USER3"
    [3]=>
    string(5) "USER3"
    ["credit_card_cvc"]=>
    string(3) "333"
    [4]=>
    string(3) "333"
  }
}