### PR TITLE
32 add db stock update

### DIFF
--- a/logic/db_mod.php
+++ b/logic/db_mod.php
@@ -91,3 +91,19 @@ function insertDbCreditCard(PDO $dbh, string $member_cd, string $number, string 
     $stmt->bindParam(':cvc', $cvc);
     $stmt->execute();
 }
+
+/**
+ * @brief 在庫を更新する。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $product_id [int] 更新する商品のID。
+ * @param $stock_num [int] 更新する在庫数。
+ */
+function updateDbStock(PDO $dbh, int $product_id, int $stock_num): void {
+    $sql = "UPDATE `t_stock`
+            SET `stock_num` = :stock_num
+            WHERE `product_id` = :product_id";
+    $stmt = $dbh->prepare($sql);
+    $stmt->bindParam(':stock_num', $stock_num, PDO::PARAM_INT);
+    $stmt->bindParam(':product_id', $product_id, PDO::PARAM_INT);
+    $stmt->execute();
+}

--- a/test/test_update_db_stock.php
+++ b/test/test_update_db_stock.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file test_update_db_stock.php
+ * @brief updateDbStock() の単体テスト。
+ * @author nagata
+ */
+
+require_once __DIR__ . '/../logic/db_access.php';
+require_once __DIR__ . '/../logic/db_mod.php';
+
+/**
+ * @brief 在庫を更新する関数の単体テスト。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $product_id [int] 更新する商品のID。
+ * @param $stock_num [int] 更新する在庫数。
+ */
+function testUpdateDbStock(PDO $dbh, int $product_id, int $stock_num): void {
+    updateDbStock($dbh, $product_id, $stock_num);
+    var_dump(getDbAll($dbh, 't_stock'));
+}
+
+$dbh = openDb();
+testUpdateDbStock($dbh, 1, 100);


### PR DESCRIPTION
# 概要
#32 の通り、在庫を更新する関数を実装。

# 単体テストの結果
php .\test\test_update_db_stock.php      
array(2) {
  [0]=>
  array(4) {
    ["product_id"]=>
    int(1)
    [0]=>
    int(1)
    ["stock_num"]=>
    int(100)
    [1]=>
    int(100)
  }
  [1]=>
  array(4) {
    ["product_id"]=>
    int(2)
    [0]=>
    int(2)
    ["stock_num"]=>
    int(20)
    [1]=>
    int(20)
  }
}