### PR TITLE
38 add xss ignore br

### DIFF
--- a/logic/string_manipulation.php
+++ b/logic/string_manipulation.php
@@ -9,6 +9,15 @@
  * @param $string [string] XSS対策する文字列。
  * @retval [string] XSS対策後の文字列。
  */
-function str2html(string $string) :string {
+function str2html(string $string): string {
     return htmlspecialchars($string, ENT_QUOTES, 'UTF-8');
+}
+
+/**
+ * @brief <br>以外をhtmlspecialchars()でXSS対策する。
+ * @param $string [string] XSS対策する文字列。
+ * @retval [string] <br>以外、XSS対策した文字列。
+ */
+function str2htmlIgnoreBr(string $string) :string {
+    return str_replace('&lt;br&gt;', '<br>', str2html($string)); 
 }

--- a/test/test_string_manipulation.php
+++ b/test/test_string_manipulation.php
@@ -12,8 +12,21 @@ require_once __DIR__ . '/../logic/string_manipulation.php';
  * @retval [string] XSS対策後の文字列。
  */
 function testStr2html(string $string): void {
+    echo 'str2html : ';
     echo $string . ' -> ';
-    echo str2html($string);
+    echo str2html($string) . '<br>' . PHP_EOL;
+}
+
+/**
+ * @brief <br>以外をhtmlspecialchars()でXSS対策する関数の単体テスト。
+ * @param $string [string] XSS対策する文字列。
+ * @retval [string] <br>以外、XSS対策した文字列。
+ */
+function testStr2htmlIgnoreBr(string $string): void {
+    echo 'testStr2htmlIgnoreBr : ';
+    echo $string . ' -> ';
+    echo str2htmlIgnoreBr($string) . '<br>' . PHP_EOL;;
 }
 
 testStr2html('<br><script></script>');
+testStr2htmlIgnoreBr('<br><script></script>');


### PR DESCRIPTION
# 概要
#38 の通り、brタグ以外をサニタイジングする関数を実装。

# 単体テストの結果
str2html : \<br><script></script> -> \&lt;br\&gt;\&lt;script\&gt;\&lt;/script\&gt;<br>
testStr2htmlIgnoreBr : \<br><script></script> -> \<br>\&lt;script\&gt;\&lt;/script\&gt;<br>