### PR TITLE
46 add login logout

### DIFF
--- a/logic/db_access.php
+++ b/logic/db_access.php
@@ -44,7 +44,7 @@ function getDbAll(PDO $dbh, string $tableName): array {
  * @retval [array] DBから取得したメールアドレスとパスワード、氏名を格納した配列。
  */
 function getLoginInfo(PDO $dbh, string $email): array {
-    $sql = "SELECT `member_email`, `member_password`, `member_name`
+    $sql = "SELECT `member_cd`, `member_email`, `member_password`, `member_name`
             FROM `m_member`
             WHERE `member_email` = :member_email";
     $stmt = $dbh->prepare($sql);

--- a/logic/login_logic.php
+++ b/logic/login_logic.php
@@ -38,7 +38,7 @@ function tryLogin(string $email, string $password): bool{
         $masterInfo = getLoginInfo($dbh, $email);
         // メールアドレスまたはパスワードがないとき
         if(empty($masterInfo[0]['member_email']) || empty($masterInfo[0]['member_password'])){
-            $_SESSION['login'] = false;
+            // $_SESSION['login'] = false;
             return false;
         }
         // メールアドレスとパスワードが一致したとき
@@ -51,12 +51,20 @@ function tryLogin(string $email, string $password): bool{
             return true;
         // メールアドレスかパスワードが間違っているとき
         } else {
-            $_SESSION['login'] = false;
+            // $_SESSION['login'] = false;
             return false;
         }
     } catch(PDOException $e) {
         // echo 'エラー！：' . str2html($e->getMessage());
-        $_SESSION['login'] = false;
+        // $_SESSION['login'] = false;
         return false;
     }
+}
+
+/**
+ * @brief ログアウト処理。
+ */
+function logout(): void{
+    $_SESSION = [];
+    session_destroy();
 }

--- a/logic/login_logic.php
+++ b/logic/login_logic.php
@@ -1,25 +1,62 @@
 <?php
 /**
  * @file login_logic.php
- * @brief implements login logic.
+ * @brief ログイン処理を実装。
  * @author nagata
  */
 
+require_once __DIR__ . '/../logic/db_access.php';
+
 /**
- * @brief to hashing.
- * @param $toBeHash [string] string to be hashed.
- * @retval [string] after hashing.
+ * @brief 文字列をハッシュ化する。
+ * @param $toBeHash [string] ハッシュ化する文字列。
+ * @retval [string] ハッシュ化後の文字列。
  */
 function toHash(string $toBeHash): string{
     return password_hash($toBeHash, PASSWORD_DEFAULT);
 }
 
 /**
- * @brief is match id.
- * @param $inputId [string] user input id.
- * @param $masterId [string] id stored in DB.
- * @retval [string] is match id.
+ * @brief IDが整合するかチェックする。
+ * @param $inputId [string] ユーザの入力したID。
+ * @param $masterId [string] DBに保存されているID。
+ * @retval [bool] IDが整合したかどうか。 
  */
-function isMatchId(string $inputId, string $masterId){
+function isMatchId(string $inputId, string $masterId): bool{
     return $inputId === $masterId;
+}
+
+/**
+ * @brief ログイン認証。
+ * @param $email [string] メールアドレス。
+ * @param $password [string] ハッシュ化前のパスワード。
+ * @retval [bool] ログインできたか。
+ */
+function tryLogin(string $email, string $password): bool{
+    try {
+        $dbh = openDb();
+        $masterInfo = getLoginInfo($dbh, $email);
+        // メールアドレスまたはパスワードがないとき
+        if(empty($masterInfo[0]['member_email']) || empty($masterInfo[0]['member_password'])){
+            $_SESSION['login'] = false;
+            return false;
+        }
+        // メールアドレスとパスワードが一致したとき
+        if(isMatchId($email, $masterInfo[0]['member_email']) &&
+           password_verify($password, $masterInfo[0]['member_password'])){
+            session_regenerate_id(true);
+		    $_SESSION['login'] = true;
+		    $_SESSION['username'] = $masterInfo[0]['member_name'];
+            $_SESSION['member_cd'] = $masterInfo[0]['member_cd'];
+            return true;
+        // メールアドレスかパスワードが間違っているとき
+        } else {
+            $_SESSION['login'] = false;
+            return false;
+        }
+    } catch(PDOException $e) {
+        // echo 'エラー！：' . str2html($e->getMessage());
+        $_SESSION['login'] = false;
+        return false;
+    }
 }

--- a/test/test_db_access.php
+++ b/test/test_db_access.php
@@ -13,7 +13,7 @@ require_once __DIR__ . '/../logic/db_access.php';
 function testOpenDb(): void {
     $dbh = openDb();
     $assertEqual = ((get_class($dbh) === 'PDO') ? 'passed' : 'failed');
-    echo 'testGetSaltTrue : ' . $assertEqual . '<br>' . PHP_EOL;
+    echo 'testGetOpenDb : ' . $assertEqual . '<br>' . PHP_EOL;
 }
 
 /**
@@ -37,6 +37,7 @@ function testGetDbAll(PDO $dbh, string $tableName): void {
 function testGetLoginInfo(PDO $dbh, string $email): void {
     $loginInfo = getLoginInfo($dbh, $email);
     echo 'testGetLoginInfo : ' . '<br>' . PHP_EOL;
+    echo ' 会員コード:' . $loginInfo[0]['member_cd'] . '<br>' . PHP_EOL;
     echo ' メール:' . $loginInfo[0]['member_email'] . '<br>' . PHP_EOL;
     echo ' パスワード:' . $loginInfo[0]['member_password'] . '<br>' . PHP_EOL;
     echo ' ユーザ名:' . $loginInfo[0]['member_name'] . '<br>' . PHP_EOL;
@@ -78,13 +79,21 @@ function testSearchProductFmDb(PDO $dbh, string $searchWord): void {
 }
 
 testOpenDb();
+echo '<br>' . PHP_EOL;
 testGetDbAll(openDb(), 'm_product');
 testGetDbAll(openDb(), 'm_member');
+echo '<br>' . PHP_EOL;
 testGetLoginInfo(openDb(), 'user1@example.com');
 testGetLoginInfo(openDb(), 'user2@example.com');
+echo '<br>' . PHP_EOL;
 testGetDbSelected(openDb(), 't_group', 'group_id', 1);
+echo '<br>' . PHP_EOL;
 testGetDbSelected(openDb(), 't_season', 'season_id', 1);
+echo '<br>' . PHP_EOL;
 testGetDbSalesRank(openDb(), 1);
+echo '<br>' . PHP_EOL;
 testGetDbSalesRank(openDb(), 3);
+echo '<br>' . PHP_EOL;
 testSearchProductFmDb(openDb(), '商品');
+echo '<br>' . PHP_EOL;
 testSearchProductFmDb(openDb(), '存在しない');

--- a/test/test_login.php
+++ b/test/test_login.php
@@ -1,0 +1,39 @@
+<?php
+// ログインの判定やカート情報の保持が必要なページ全てに入れる。
+session_start();
+?>
+<?php
+/**
+ * @file test_login.php
+ * @brief tryLogin()の単体テスト
+ */
+
+require_once __DIR__ . '/../logic/login_logic.php';
+
+$isLogin = tryLogin('user1@example.com', 'password1');
+echo 'ログイン情報が一致:';
+var_dump($isLogin);
+echo '<br>' . PHP_EOL . "\$_SESSION['login']:";
+var_dump($_SESSION['login']);
+echo '<br>' . PHP_EOL . "\$_SESSION['username']:";
+var_dump($_SESSION['username']);
+echo '<br>' . PHP_EOL . "\$_SESSION['member_cd']:";
+var_dump($_SESSION['member_cd']);
+
+$isLogin = tryLogin('user1@example.co', 'password1');
+echo '<br>' . PHP_EOL . 'メールアドレスが誤り:';
+var_dump($isLogin);
+echo '<br>' . PHP_EOL . "\$_SESSION['login']:";
+var_dump($_SESSION['login']);
+
+$isLogin = tryLogin('user1@example.com', 'password');
+echo '<br>' . PHP_EOL . 'パスワードが誤り:';
+var_dump($isLogin);
+echo '<br>' . PHP_EOL . "\$_SESSION['login']:";
+var_dump($_SESSION['login']);
+
+$isLogin = tryLogin('user1@example.co', 'password');
+echo '<br>' . PHP_EOL . 'メールアドレスとパスワードが誤り:';
+var_dump($isLogin);
+echo '<br>' . PHP_EOL . "\$_SESSION['login']:";
+var_dump($_SESSION['login']);

--- a/test/test_logout.php
+++ b/test/test_logout.php
@@ -1,0 +1,26 @@
+<?php
+// ログインの判定やカート情報の保持が必要なページ全てに入れる。
+session_start();
+?>
+<?php
+/**
+ * @file test_logout.php
+ * @brief logout()の単体テスト
+ */
+
+require_once __DIR__ . '/../logic/login_logic.php';
+
+$isLogin = tryLogin('user1@example.com', 'password1');
+echo 'ログイン情報が一致:';
+var_dump($isLogin);
+echo '<br>' . PHP_EOL . "\$_SESSION['login']:";
+var_dump($_SESSION['login']);
+echo '<br>' . PHP_EOL . "\$_SESSION['username']:";
+var_dump($_SESSION['username']);
+echo '<br>' . PHP_EOL . "\$_SESSION['member_cd']:";
+var_dump($_SESSION['member_cd']);
+
+logout();
+echo '<br>' . PHP_EOL . 'ログアウト';
+echo '<br>' . PHP_EOL . "\$_SESSION:";
+var_dump($_SESSION);


### PR DESCRIPTION
# 概要
#46 の通りログイン・ログアウトを行う関数を実装。  
単体テストでセッション情報が期待値通りになっていることを確認。

# 単体テストの結果
## test_login.php
ログイン情報が一致:bool(true)
$_SESSION['login']:bool(true)
$_SESSION['username']:string(15) "ユーザ太郎"
$_SESSION['member_cd']:int(1)
メールアドレスが誤り:bool(false)
$_SESSION['login']:bool(true)
パスワードが誤り:bool(false)
$_SESSION['login']:bool(true)
メールアドレスとパスワードが誤り:bool(false)
$_SESSION['login']:bool(true)

## test_logout.php
ログイン情報が一致:bool(true)
$_SESSION['login']:bool(true)
$_SESSION['username']:string(15) "ユーザ太郎"
$_SESSION['member_cd']:int(1)
ログアウト
$_SESSION:array(0) { }