### PR TITLE
57 add insert db sales

### DIFF
--- a/logic/db_mod.php
+++ b/logic/db_mod.php
@@ -137,3 +137,23 @@ function insertDbCustomerInfo(PDO $dbh, string $customer_zip_code, int $prefectu
     $stmt->bindParam(':payment_cd', $payment_cd, PDO::PARAM_INT);
     $stmt->execute();
 }
+
+/**
+ * @brief 売上情報をDBに保存。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $customer_id [int] 購入者ID。
+ * @param $product_id [int] 商品ID。
+ * @param $sales_num [int] 個数。
+ * @param $sales_date [string] 購入日。
+ */
+function insertDbSales(PDO $dbh, int $customer_id, int $product_id, int $sales_num,
+                       string $sales_date): void {
+    $sql = "INSERT INTO `t_sales` (`customer_id`, `product_id`, `sales_num`, `sales_date`) 
+            VALUES (:customer_id, :product_id, :sales_num, :sales_date)";
+    $stmt = $dbh->prepare($sql);
+    $stmt->bindParam(':customer_id', $customer_id, PDO::PARAM_INT);
+    $stmt->bindParam(':product_id', $product_id, PDO::PARAM_INT);
+    $stmt->bindParam(':sales_num', $sales_num, PDO::PARAM_INT);
+    $stmt->bindParam(':sales_date', $sales_date, PDO::PARAM_STR);
+    $stmt->execute();
+}

--- a/test/test_insert_db_sales.php
+++ b/test/test_insert_db_sales.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * @file test_insert_db_sales.php
+ * @brief insertDbSales() の単体テスト。
+ * @author nagata
+ */
+
+require_once __DIR__ . '/../logic/db_access.php';
+require_once __DIR__ . '/../logic/db_mod.php';
+
+/**
+ * @brief insertDbSales()で、売上情報をDBに保存できているか単体テスト。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $customer_id [int] 購入者ID。
+ * @param $product_id [int] 商品ID。
+ * @param $sales_num [int] 個数。
+ * @param $sales_date [string] 購入日。
+ */
+function testInsertDbSales(PDO $dbh, int $customer_id, int $product_id,
+                           int $sales_num, string $sales_date): void {
+    insertDbSales($dbh, $customer_id, $product_id, $sales_num, $sales_date);
+    var_dump(getDbAll($dbh, 't_sales'));
+}
+
+$dbh = openDb();
+testInsertDbSales($dbh, 2, 1, 20, date('Y-m-d'));


### PR DESCRIPTION
# 概要
#57 の通り、売上テーブルにレコードを追加する関数を実装。  
単体テストにて、売上情報をDBに保存できていることを確認。  

# 単体テストの結果
## test_insert_db_sales.php
![image](https://github.com/user-attachments/assets/699e82bd-d104-48d0-a4b8-ba1942ea4c7b)
