### PR TITLE
59 add insert db buy history

### DIFF
--- a/logic/db_mod.php
+++ b/logic/db_mod.php
@@ -157,3 +157,18 @@ function insertDbSales(PDO $dbh, int $customer_id, int $product_id, int $sales_n
     $stmt->bindParam(':sales_date', $sales_date, PDO::PARAM_STR);
     $stmt->execute();
 }
+
+/**
+ * @brief ログイン中のとき、ユーザの購入履歴をDBに保存。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $member_cd [int] 会員コード。
+ * @param $sales_id [int] 売上ID。
+ */
+function insertDbBuyHistory(PDO $dbh, int $member_cd, int $sales_id): void {
+    $sql = "INSERT INTO `t_buy_history` (`member_cd`, `sales_id`)
+            VALUES (:member_cd, :sales_id)";
+    $stmt = $dbh->prepare($sql);
+    $stmt->bindParam(':member_cd', $member_cd, PDO::PARAM_INT);
+    $stmt->bindParam(':sales_id', $sales_id, PDO::PARAM_INT);
+    $stmt->execute();
+}

--- a/test/test_insert_db_buy_history.php
+++ b/test/test_insert_db_buy_history.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @file test_insert_db_buy_history.php
+ * @brief insertDbBuyHistory() の単体テスト。
+ * @author nagata
+ */
+
+require_once __DIR__ . '/../logic/db_access.php';
+require_once __DIR__ . '/../logic/db_mod.php';
+
+/**
+ * @brief insertDbBuyHistory()でユーザの購入履歴をDBに保存できているか単体テスト。
+ * @param $dbh [PDO] db_open()で取得したデータベースオブジェクトを指定。
+ * @param $member_cd [int] 会員コード。
+ * @param $sales_id [int] 売上ID。
+ */
+function testInsertDbBuyHistory(PDO $dbh, int $member_cd, int $sales_id): void {
+    insertDbBuyHistory($dbh, $member_cd, $sales_id);
+    var_dump(getDbAll($dbh, 't_buy_history'));
+}
+
+$dbh = openDb();
+testInsertDbBuyHistory($dbh, 2, 1);


### PR DESCRIPTION
# 概要
#59 の通り、ログイン中のユーザの購入履歴テーブルにレコードを追加する関数を実装。
単体テストにて、insertDbBuyHistory()でユーザの購入履歴をDBに保存できていることを確認。

# 単体テストの結果
## test_insert_db_buy_history.php
![image](https://github.com/user-attachments/assets/b131618f-13ac-4eea-b9ee-ab226530fea0)
